### PR TITLE
chore: add Steel Browser to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
+* [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 
 ### Related tools
 


### PR DESCRIPTION
Steel Browser is an open-source browser sandbox and API for AI agents, built for session-backed web automation and artifact capture.

This fits the `AI` section because it gives agents a real browser with explicit session control, extraction, screenshots/PDFs, and anti-bot support.

Links:
- Repo: https://github.com/steel-dev/steel-browser
- Docs: https://docs.steel.dev/llms-full.txt
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: browser automation for multi-step web flows with verifiable screenshots and PDFs.