### PR TITLE
Add Hanzi

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Browser automation is the act of executing actions automatically in a web browse
 
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [Hanzi](https://github.com/hanzili/hanzi-in-chrome) - MCP server + Chrome extension for task-level browser automation using your real signed-in browser.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.


### PR DESCRIPTION
Adds [Hanzi](https://github.com/hanzili/hanzi-in-chrome) to the AI section.

Hanzi is an MCP server + Chrome extension that gives AI agents access to your real signed-in browser for task-level automation. Unlike headless tools, it uses your actual browser session.

- Category: AI
- npm: `hanzi-in-chrome`
- Open source