### PR TITLE
Add UI Annotator MCP to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
+* [UI Annotator MCP](https://github.com/mcpware/ui-annotator-mcp) - MCP server that annotates web pages with hover labels for AI assistants. Uses a reverse proxy — no browser extensions needed, works in any browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 
 ### Related tools


### PR DESCRIPTION
Adds [UI Annotator MCP](https://github.com/mcpware/ui-annotator-mcp) — an MCP server that annotates web pages with hover labels for AI assistants. Uses a reverse proxy to inject annotations, works in any browser without extensions.

Split from #79 as requested — one tool per PR.