### PR TITLE
Add CDPilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Axiom](https://axiom.ai) - No code browser automation tool, like Zapier.
 * [Browserflow](https://browserflow.app) - Chrome extension to automate your local browser or in the cloud.
 * [Capybara](https://github.com/teamcapybara/capybara) - Driver-agnostic tool and DSL to write automation tests in Ruby.
+* [CDPilot](https://github.com/mehmetnadir/cdpilot) - Zero-dependency CLI for browser automation via Chrome DevTools Protocol with 40+ commands and MCP server for AI agents.
 * [Chromedp](https://github.com/chromedp/chromedp) - Browser automation through Chrome DevTools Protocol fully implemented in Go.
 * [Codeception](https://github.com/codeception/codeception) - PHP end-to-end testing with BDD style.
 * [CodeceptJS](https://github.com/Codeception/CodeceptJS) - BDD style tests with support for multiple headless browsers.


### PR DESCRIPTION
## Add CDPilot

[CDPilot](https://github.com/mehmetnadir/cdpilot) — Zero-dependency CLI for browser automation via Chrome DevTools Protocol with 40+ commands and MCP server for AI agents.

### Why it belongs here

- **Pure CDP implementation** — communicates directly with Chromium browsers over Chrome DevTools Protocol (HTTP + WebSocket), no wrapper libraries
- **Zero dependencies** — Python stdlib + Node.js stdlib only (no Playwright, Puppeteer, or Selenium)
- **40+ automation commands** — navigation, clicking, form filling, screenshots, PDF export, network interception, device emulation, geolocation override, cookie management, accessibility audits
- **AI agent integration** — built-in MCP server for Claude Code and other AI coding assistants
- **Cross-platform** — macOS, Linux, Windows
- **MIT license**

### Category

Added to **Tools** section in alphabetical order (between Capybara and Chromedp).

### Links

- GitHub: https://github.com/mehmetnadir/cdpilot
- npm: `npx cdpilot launch`