### PR TITLE
Add pilot-mcp — fast browser automation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
+* [pilot-mcp](https://github.com/TacosyHorchata/Pilot) - Fast MCP browser automation server. In-process Playwright, 58 tools (profiles: 9/28/58), cookie import from Chrome/Arc/Brave, handoff/resume for CAPTCHAs, iframe support. 41% faster than @playwright/mcp.
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 


### PR DESCRIPTION
Adds [pilot-mcp](https://github.com/TacosyHorchata/Pilot) alongside the existing Playwright MCP entry.

pilot-mcp is a fast browser automation MCP server:
- In-process Playwright (no HTTP layer) — ~5ms per action vs ~100-200ms
- 41% faster than @playwright/mcp in benchmarks (25s vs 43s across 5 tasks)
- 58 tools with configurable profiles (9/28/58)
- Cookie import from Chrome/Arc/Brave via macOS Keychain
- Handoff/Resume for CAPTCHAs and bot detection
- Full iframe support
- MIT license, npm: `pilot-mcp`