### PR TITLE
Add Safari MCP to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
+* [Safari MCP](https://github.com/achiya-automation/safari-mcp) - Native Safari browser automation for AI agents via AppleScript. 80 tools, zero Chrome overhead, keeps logins.
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 


### PR DESCRIPTION
## Summary
- Adds [Safari MCP](https://github.com/achiya-automation/safari-mcp) to the AI subsection
- Native Safari browser automation for AI agents on macOS — 80 tools via AppleScript + JavaScript, zero Chrome overhead, keeps all logins
- MIT licensed, available on npm as `safari-mcp`

## Checklist
- [x] Entry follows existing format (`* [Name](url) - Description.`)
- [x] Alphabetically ordered (between "Playwright MCP" and "Skyvern")
- [x] Project fits the AI browser automation category