### PR TITLE
Add BabelWrap to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Browser automation is the act of executing actions automatically in a web browse
 ### AI
 
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
+* [BabelWrap](https://babelwrap.com) - HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)


### PR DESCRIPTION
Adds [BabelWrap](https://babelwrap.com) to the AI section.

BabelWrap is an HTTP API and MCP server that lets AI agents interact with any website through natural language descriptions instead of CSS selectors. Agents describe what they want to do in plain English (e.g., "click the Login button", "fill the email field") and BabelWrap translates these into real browser interactions.

- **Website:** https://babelwrap.com
- **MCP Docs:** https://babelwrap.com/docs/mcp
- **GitHub:** https://github.com/babelwrap/babelwrap-mcp
- **PyPI:** https://pypi.org/project/babelwrap-mcp/

Placed alphabetically in the AI section (before Browser-Use).