### PR TITLE
Add ClawBench to AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Browser automation is the act of executing actions automatically in a web browse
 
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [ClawBench](https://github.com/reacher-z/ClawBench) - Benchmark of 153 everyday tasks on live production websites for evaluating AI browser agents beyond sandboxed environments.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.


### PR DESCRIPTION
Adds ClawBench to the AI tools section.

ClawBench is a benchmark of 153 everyday web tasks across 144 live production websites in 15 categories, for evaluating AI browser agents on real-world conditions rather than sandboxed replicas. Adjacent in scope to Browser-Use; complementary as an evaluation target.

- Repo: https://github.com/reacher-z/ClawBench
- Paper: https://huggingface.co/papers/2604.08523

**Affiliation disclosure:** I'm a maintainer of ClawBench. Entry kept factual, matched existing section style.