### PR TITLE
Add OpenTwins under Tools › AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
+* [OpenTwins](https://github.com/Open-Twin/opentwins) - CLI that drives real Chrome sessions via CDP to run autonomous AI agents on 10 social platforms, powered by Claude Code.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.


### PR DESCRIPTION
## Adding OpenTwins

**Project:** [OpenTwins](https://github.com/Open-Twin/opentwins) — CLI that drives real Chrome sessions via CDP to run autonomous AI agents on 10 social platforms.

**Section:** Tools › AI (inserted alphabetically between Openwork and Playwright MCP)

**Why it belongs:**
- AI-powered browser automation tool — uses raw Chrome DevTools Protocol (CDP), no Puppeteer/Playwright wrapper
- Autonomous agents driven by Claude Code navigate and interact with real browser sessions on 10 social platforms
- Open source, MIT, actively maintained
- Has README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, CHANGELOG, tests
- Published on npm: https://www.npmjs.com/package/opentwins

**Checklist:**
- [x] Entry follows existing style (one-line dash-separated description)
- [x] Inserted alphabetically (between Openwork and Playwright MCP)
- [x] Link returns 200
- [x] No duplicate entry