### PR TITLE
Add Rove to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
+* [Rove](https://roveapi.com) - Hosted Playwright-as-a-Service for AI agents. Returns accessibility trees instead of screenshots. MCP-native with REST API.
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 


### PR DESCRIPTION
Adds [Rove](https://roveapi.com) to the AI section.

Rove is a hosted Playwright-as-a-Service built for AI agents. Key differentiators:

- **Accessibility trees over screenshots** — returns structured a11y data instead of pixel-based output, giving agents semantic understanding of page content
- **MCP-native** — first-class Model Context Protocol server, plus a REST API
- **Zero infrastructure** — fully hosted, no browser instances to manage

GitHub: https://github.com/noncelogic/rove

The entry is placed alphabetically in the existing AI subsection.