### PR TITLE
Add Tap to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
+* [Tap](https://github.com/LeonTing1010/tap) - MCP server that compiles AI browser intent into deterministic `.tap.json` plans, runs on your logged-in Chrome, and detects drift via semantic fingerprint diff when sites change.
 
 ### Related tools
 


### PR DESCRIPTION
Adds [Tap](https://github.com/LeonTing1010/tap) under **AI**.

Tap is an MCP server that compiles AI browser automation into deterministic `.tap.json` plans (25-op closed union, zero runtime LLM), runs on the user's logged-in Chrome (or headless Playwright), and detects drift via semantic fingerprint diff when sites change.

Distinct from existing AI-section entries, which all keep AI in the hot path:
- **Alumnium / Browser-Use / Skyvern**: LLM runs at each step.
- **Playwright MCP**: direct Playwright bindings with runtime LLM.
- **Steel Browser**: cloud sandbox; fresh/anonymous browsers.

Tap moves the AI call to author-time (forge). Runtime is pure program replay.

- 65+ open community taps on 40+ sites
- Installs into Claude Code / Cursor / Cline / Windsurf / VS Code via `tap mcp connect`
- Proprietary core + MIT extension + MIT community taps
- Glama listing with A-A-B score: https://glama.ai/mcp/servers/LeonTing1010/tap

Format follows CONTRIBUTING.md: alphabetical insertion (after Steel Browser), capital start, full-stop end, direct link.

(Resubmission of #84, closed 2026-04-01 with no comments. Entry rewritten with current v0.13.x positioning — the older PR used stale "8 kernel primitives + 16 stdlib" language.)