### PR TITLE
Add LocoPilot to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
+* [LocoPilot](https://github.com/bobfromarcher/LocoPilot) - Vision, browser, and desktop control for any local LLM. 16 browser automation endpoints via Playwright, runs on localhost via Ollama.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)


### PR DESCRIPTION
## Summary

Adds [LocoPilot](https://github.com/bobfromarcher/LocoPilot) to the AI subsection under Tools.

LocoPilot provides 16 browser automation endpoints via Playwright for any local LLM, plus vision and desktop control endpoints (35 total). It runs fully on localhost via Ollama with zero cloud dependencies and is MIT-licensed.

Placed alphabetically between Libretto and onUI, matching the existing list format.