### PR TITLE
Add Taprun to AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
+* [Taprun](https://github.com/LeonTing1010/tap) - MCP server that compiles AI browser automation into deterministic `.tap.json` plans (25-op closed union, zero runtime LLM), runs on your logged-in Chrome, and detects drift via semantic fingerprint diff when sites change. 65+ open community taps on 40+ sites.
 
 ### Related tools
 


### PR DESCRIPTION
Adds Taprun to the AI section. Taprun is an MCP server that compiles AI browser automation into deterministic `.tap.json` plans, so the LLM is only invoked once at authoring time and replays at zero token cost on subsequent runs. It targets the user's logged-in Chrome (no `--remote-debugging-port`), and detects drift via semantic fingerprint diff when sites change.

Source: https://github.com/LeonTing1010/tap
Site: https://taprun.dev
65+ open community taps live in https://github.com/LeonTing1010/tap-skills.