### PR TITLE
Add Tap to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
+* [Tap](https://github.com/LeonTing1010/tap) - MCP server that compiles browser automation into deterministic plans — replay AI agent flows at zero LLM tokens with drift detection.
 
 ### Related tools
 


### PR DESCRIPTION
Adds [Tap](https://github.com/LeonTing1010/tap) to the AI subsection of `## Tools`, alphabetically after Steel Browser.

Tap is an MCP server (also available as CLI / npm packages / Python SDK) that compiles browser automation into deterministic `.tap.json` plans. It fits alongside Browser-Use, Playwright MCP, Skyvern, and Steel Browser — same general space (AI + browser automation), different angle: Tap's wedge is replaying agent flows without re-invoking the LLM at runtime.

Distribution clean and publicly auditable:

- Source (MIT, public): https://github.com/LeonTing1010/tap
- npm: [@taprun/cli](https://www.npmjs.com/package/@taprun/cli) and 4 sibling packages
- PyPI: [taprun](https://pypi.org/project/taprun/)
- MCP Registry (Anthropic-curated): `io.github.LeonTing1010/tap`
- Already listed in: punkpeye/awesome-mcp-servers, PulseMCP, Smithery, Glama
- Docs: https://taprun.dev/

Adheres to CONTRIBUTING.md:
- One link per entry, alphabetical within section
- Description starts with a capital, ends with a period
- No trailing slashes / shorteners
- Direct link to GitHub source
- AI subsection per the maintained tool placement rule