### PR TITLE
Add Uni-CLI to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
-* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 237+ websites and apps as deterministic commands for AI agents via 920 declarative YAML browser-automation adapters and structured error envelopes; agents fix failing adapters at runtime and retry.
+* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, and browser automation as deterministic commands for AI agents (counts from the repo's live README STATS counters). Declarative YAML adapters with structured error envelopes; agents fix failing adapters at runtime and retry.
 
 ### Related tools
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
-* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, and browser automation as deterministic commands for AI agents (counts from the repo's live README STATS counters). Declarative YAML adapters with structured error envelopes; agents fix failing adapters at runtime and retry.
+* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog that exposes web, desktop, and browser-automation surfaces as deterministic commands for AI agents. Declarative YAML adapters with structured error envelopes; agents fix failing adapters at runtime and retry. Live catalog size tracked in the repo's [README](https://github.com/olo-dot-io/Uni-CLI#readme).
 
 ### Related tools
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
+* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Self-repairing CLI catalog exposing 237+ websites and apps as deterministic commands for AI agents via 920 declarative YAML browser-automation adapters and structured error envelopes; agents fix failing adapters at runtime and retry.
 
 ### Related tools
 


### PR DESCRIPTION
## What
Adds [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) to **Tools → AI**, alphabetically after `Steel Browser`.

## Why this section
Per CONTRIBUTING: "If a tool is primarily focused on AI, or to be used with AI (e.g. Agents, MCP, automation with prompts), please put it under the AI section." Uni-CLI is built specifically for AI agents — every design decision (structured error envelopes, ~80-token median calls, agent-editable YAML adapters) targets machine consumption.

## What it does
Self-repairing CLI catalog that exposes **237+ websites and apps** as deterministic commands for AI agents. 920 declarative YAML browser-automation adapters; structured error envelopes (`code`, `adapter_path`, `step`, `suggestion`) so when a site rotates a selector, the calling agent edits the YAML at `adapter_path` and retries.

## Format
- `* [Tool](link) - Description.` — capital, period, alphabetical.
- Inserted at correct alphabetical position (after `Steel Browser`).
- Direct link, no shortener; available; markdown valid.

## Project signals
- Apache-2.0, TypeScript strict, actively maintained (release v0.218.0 today, 2026-05-05).
- npm: [`@zenalexa/unicli`](https://www.npmjs.com/package/@zenalexa/unicli).
- Docs: https://olo-dot-io.github.io/Uni-CLI/