### PR TITLE
Add Human Browser — stealth Playwright browser with residential proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [Human Browser](https://humanbrowser.cloud) - Stealth Playwright browser with residential proxy for AI agents. Bypasses Cloudflare, DataDome, PerimeterX. Free trial, no signup.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.


### PR DESCRIPTION
**Human Browser** is a Playwright-based stealth browser designed specifically for AI agents.

- Bypasses Cloudflare, DataDome, PerimeterX via residential IP + device fingerprint
- iPhone 15 Pro fingerprint (canvas, WebGL, fonts, TLS)
- Human-like behavior simulation (Bezier mouse, natural typing)
- Free 100MB trial, no signup required
- `npm install human-browser`

Website: https://humanbrowser.cloud
npm: https://npmjs.com/package/human-browser

Fits in the **AI Agents** section alongside Steel Browser, CamoFox, Playwright MCP.