### PR TITLE
Add WebOperator — AI browser agent as Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 * [CamoFox Browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser for AI agents built on a Firefox fork with C++ fingerprint spoofing to bypass Cloudflare, Akamai, and bot detection.
+* [WebOperator](https://github.com/KazKozDev/WebOperator) - Chrome extension browser agent with a pure agent loop (observe → decide → act → verify). One tool call at a time, plan enforcement. Works locally with Ollama. TypeScript, MIT.
 
 ### Related tools
 


### PR DESCRIPTION
Added [WebOperator](https://github.com/KazKozDev/WebOperator) to the AI section — a Chrome extension browser agent with a pure agent loop. One tool call at a time, plan enforcement, works locally with Ollama. TypeScript, MIT.