### PR TITLE
Add LinkedIn AI Job Applier to AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
+* [LinkedIn AI Job Applier](https://github.com/beatwad/LinkedIn-AI-Job-Applier-Ultimate) - Python AI agent using Playwright to automate job search and applications on LinkedIn and Indeed with multi-LLM support, intelligent job search, form filling, and resume generation.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)


### PR DESCRIPTION
## What
Adds [LinkedIn AI Job Applier](https://github.com/beatwad/LinkedIn-AI-Job-Applier-Ultimate) to the AI subsection under Tools.

## Why it belongs here
- Built on **Playwright** (Python) for all browser interaction
- Uses an **LLM agent** (OpenAI, Gemini, Claude, Ollama, OpenRouter) to analyze job postings, fill forms intelligently, and generate tailored resumes
- Automates complex, multi-step browser workflows across LinkedIn and Indeed
- Actively maintained open-source project