### PR TITLE
Add Browy to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [Browy](https://github.com/BrowyHQ/browy) - Open-source MV3 Chrome extension that lives in the side panel and DevTools and drives real browser tabs through chat, powered by the GitHub Copilot SDK.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.


### PR DESCRIPTION
Adds Browy under `### AI`, alphabetised right after Browser-Use.

[Browy](https://github.com/BrowyHQ/browy) is an open-source MV3 Chrome extension (Apache-2.0, ~95% TS/JS) that lets you drive real browser tabs through chat. It runs in two places at once:

- **Side panel** for day-to-day work — summarise the open page, fill out forms, scrape data into JSON, compare prices across tabs.
- **DevTools CLI** for power users — a terminal-style REPL with slash commands sitting next to Elements/Network.

Tools the agent can call include click, type, scroll, `run_js`, `read_dom`, `read_console`, `read_network`, `tabs.list`, `tabs.open`, plus opt-in host tools (shell, fs, web fetch). The backend is a Node native-messaging host that wraps the GitHub Copilot SDK, so models and quota come from the user's existing GitHub Copilot subscription rather than a new API key.

Docs: https://browyhq.github.io  ·  Chrome Web Store: https://chromewebstore.google.com/detail/iondecjdokngnlkfpipgolgkfegpmjca

Joke (per CONTRIBUTING): I asked an LLM why my browser feels so empty. It said `404: tab not found`. Browy fixes that by giving the tab someone to talk to.