### PR TITLE
Add Human Browser to Tools › AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [Human Browser](https://humanbrowser.cloud) - Stealth Playwright browser with residential proxy for AI agents. Bypasses Cloudflare, DataDome, PerimeterX. Free trial, no signup.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.


### PR DESCRIPTION
Adds **Human Browser** — a cloud stealth browser for AI agents: residential IPs, real device fingerprint, captcha solving, and an A2A + MCP endpoint behind one API. Sits in the same **Tools › AI** category as the already-listed Steel Browser, CamoFox Browser and Browser-Use. Follows the existing `* [Name](url) - description.` format, placed alphabetically after Browser-Use.

Site: https://humanbrowser.cloud