### PR TITLE
Add HUD to AI browser automation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Browser automation is the act of executing actions automatically in a web browse
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [HUD](https://github.com/hud-evals/hud-python) - Open-source Python SDK for building browser and computer-use environments to evaluate and train AI agents, with task-based rewards runnable as evals or RL training.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.


### PR DESCRIPTION
Adds **HUD** to the `### AI` section (placed in alphabetical order).

HUD is an open-source Python SDK for building browser and computer-use environments where AI agents take actions, complete tasks, and receive task-based rewards — usable as both evals and RL training. It's awesome because it makes the *environment* explicit and provider-agnostic: define your tools once, and the same environment works across Claude, GPT, and Gemini computer-use, then you can train models on the successful runs.

- Link: https://github.com/hud-evals/hud-python (MIT, 269+ stars, documented at https://docs.hud.ai)
- Added in alphabetical order, single PR, single addition, description ends with a period.

And the obligatory joke, as required by CONTRIBUTING: Why did the browser automation agent bring a ladder to the interview? It heard the job had a lot of high-level scrolling. 🪜
