### PR TITLE
Add agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Browser automation is the act of executing actions automatically in a web browse
 
 ### AI
 
+* [agent-qa](https://github.com/vostride/agent-qa) - Self-improving QA agent for natural-language web and mobile tests with run memory, UI-change adaptation, and regression detection.
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.


### PR DESCRIPTION
Summary:
- Add agent-qa to the AI browser automation section.
- Keep the change as a direct README entry only.

Why it belongs:
- agent-qa is an AI-focused QA agent for natural-language web and mobile tests, with run memory and UI-change adaptation.

Check:
- git diff --check

Joke:
- I tried to automate my coffee break, but the browser kept opening Java.