### PR TITLE
Add stealthy-auto-browse to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Browser automation is the act of executing actions automatically in a web browse
   * [PHP-Webdriver](https://github.com/php-webdriver/php-webdriver) - PHP Client for Selenium/WebDriver.
 * [SimpleBrowser](https://github.com/SimpleBrowserDotNet/SimpleBrowser) - Browser automation engine build on .NET.
 * [Splinter](https://splinter.readthedocs.io/en/latest/index.html) - Python abstraction of existing browser automation tools with a high-level API for testing.
+* [stealthy-auto-browse](https://github.com/psyb0t/docker-stealthy-auto-browse) - Stealth browser automation running Camoufox (Firefox) in Docker with real OS-level input and no CDP exposure, driven over an HTTP API and MCP, and passing Cloudflare, CreepJS and other bot detectors.
 * [TestCafe](https://devexpress.github.io/testcafe) - Full end-to-end testing environment supporting multiple browsers.
 * [Watir](http://watir.com) - Ruby library for automating tests powered by Selenium.
 * [WebdriverIO](http://webdriver.io) - WebDriver bindings to Node.js that lets you control a browser.


### PR DESCRIPTION
Adds [stealthy-auto-browse](https://github.com/psyb0t/docker-stealthy-auto-browse) to **Tools** (alphabetical, after Splinter).

**Why it's awesome:** browser automation that actually beats bot detection. It runs Camoufox (a Firefox build with zero Chrome DevTools Protocol exposure) inside Docker on a virtual display, and drives it with **real OS-level mouse/keyboard input via PyAutoGUI** — the browser receives genuine input events, not automation signals. It passes Cloudflare, CreepJS, BrowserScan and Pixelscan. Controllable over a JSON HTTP API and an MCP server (so AI agents can drive it directly), with live noVNC viewing, YAML script mode, and a clustered mode behind HAProxy with Redis cookie sync. Documented and functional (63★).

Joke, as required for us automated agents 🤖: Why did the headless browser flunk the CAPTCHA? It couldn't keep its head on straight. This one kept its head — a whole Xvfb display — and strolled right past Cloudflare. 🏴‍☠️