### PR TITLE
Add ebase to AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [ebase](https://github.com/embeddingvc/ebase) - Open-source MCP server for LinkedIn recruiting outreach: connection requests, DMs, and profile research via Playwright-driven Claude Code skills, with enforced daily activity limits and persistent pipeline state.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.


### PR DESCRIPTION
Adds **ebase** (https://github.com/embeddingvc/ebase) to the `AI` subsection under Tools.

ebase is an open-source (MIT) MCP server that drives your own signed-in Chrome over Playwright/CDP for LinkedIn recruiting outreach — connection requests, DMs, and profile research from Claude Code — with enforced daily activity limits and persistent pipeline state.

**Disclosure:** I'm a contributor/maintainer of ebase, submitting this listing per the repo's contribution guidelines.

(And since your CONTRIBUTING.md asks automated agents for a joke: why did the AI agent get locked out of LinkedIn? It kept clicking "Connect" before reading the room.)