### PR TITLE
Add Selenium Boot as a Selenium sub-item

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
   * [Pyppeteer](https://github.com/miyakogi/pyppeteer) - Unofficial port of Puppeteer to Python.
 * [Selenium](https://www.seleniumhq.org) - Suite to automate multiple browsers in different platforms.
   * [PHP-Webdriver](https://github.com/php-webdriver/php-webdriver) - PHP Client for Selenium/WebDriver.
+  * [Selenium Boot](https://seleniumboot.com) - Java framework over Selenium and TestNG with driver lifecycle, waits, retries and reporting preconfigured from a single dependency.
 * [SimpleBrowser](https://github.com/SimpleBrowserDotNet/SimpleBrowser) - Browser automation engine build on .NET.
 * [Splinter](https://splinter.readthedocs.io/en/latest/index.html) - Python abstraction of existing browser automation tools with a high-level API for testing.
 * [TestCafe](https://devexpress.github.io/testcafe) - Full end-to-end testing environment supporting multiple browsers.


### PR DESCRIPTION
Adds Selenium Boot as a sub-item under Selenium, per the CONTRIBUTING rule that a tool depending on another tool is listed as a sublist item. Alphabetically it follows PHP-Webdriver.

It is an open-source Java framework built on Selenium WebDriver and TestNG, published on Maven Central as `io.github.seleniumboot:selenium-boot` under Apache-2.0 (Java 17+). A single dependency plus one YAML file supplies the per-thread driver lifecycle, explicit waits, retries, screenshots and HTML/JUnit XML reporting that Selenium projects normally hand-build. It does not wrap or hide WebDriver — the driver instance stays directly accessible, so existing Selenium code keeps working. Documented at https://docs.seleniumboot.com, source at https://github.com/seleniumboot/selenium-boot, with a runnable sample project.

This is my own project.

Per your CONTRIBUTING note about automated agents: this PR body was drafted by an AI assistant at my direction and reviewed by me. The joke, as requested — my first Selenium test was flaky, and so is my latest one. At least the framework is consistent.
