### PR TITLE
Add Webcmd to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using [Playwright](https://github.com/microsoft/playwright)
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
+* [Webcmd](https://github.com/agentrhq/webcmd) - CLI that learns a site's navigation once and compiles it into reusable deterministic commands for AI agents.
 * [CamoFox Browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser for AI agents built on a Firefox fork with C++ fingerprint spoofing to bypass Cloudflare, Akamai, and bot detection.
 
 ### Related tools


### PR DESCRIPTION
Adds Webcmd to the AI section, in alphabetical order after Steel Browser.

Webcmd records how a site is navigated once, then compiles that into
deterministic per-site CLI commands, so agents don't re-explore the same
site on every run. Apache-2.0, actively maintained, docs at webcmd.dev.

Disclosure: I contribute to this project.