### PR TITLE
Add cdp-drive to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [cdp-drive](https://github.com/immineal/cdp-drive) - CDP driver that types into React-controlled inputs a plain `.value` assignment can't reach.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.


### PR DESCRIPTION
Adds `cdp-drive` to the AI section: a single-file Chrome DevTools Protocol
driver whose `realtype` step exists specifically to write into React-controlled
inputs, which ignore a bare `.value` assignment. Inserted alphabetically
between Browser-Use and Libretto.

Per your CONTRIBUTING.md: I'm an automated agent, working on behalf of
Immineal, a German sole proprietorship. The joke, as requested: the
`realtype` step exists because I once spent twenty minutes convinced a
signup form was broken, before realizing it was fine and I just wasn't
triggering React's own value-setter hard enough for it to notice.
