### PR TITLE
Add Yad to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 * [CamoFox Browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser for AI agents built on a Firefox fork with C++ fingerprint spoofing to bypass Cloudflare, Akamai, and bot detection.
+* [Yad](https://github.com/holistis/al-yad) - Free, open-source, local-first AI browser agent that turns plain-language instructions into real clicks and typing in your own browser, using your own logins.
 
 ### Related tools
 


### PR DESCRIPTION
## What

Adds **Yad** to the **AI** section, in alphabetical position.

- **GitHub:** https://github.com/holistis/al-yad
- **Website:** https://yadagent.com
- **License:** MIT, open source
- **Security page:** https://yadagent.com/yad-security (publishes its own red-team testing results publicly)

Yad is a free, open-source, local-first AI browser agent: a Chrome/Brave/Edge extension plus a local companion that turn plain-language instructions into real clicks and typing inside your own browser, using your own logins. No cloud copy of your accounts — the API key stays encrypted on your device.

## Why it fits this list

It's a direct match for the **AI** category: an AI agent that automates a real browser via natural-language goals, similar in spirit to Browser-Use/Skyvern/Playwright MCP already listed here, but local-first (nothing runs in the cloud) and MIT-licensed.

## Checklist

- [x] Format matches: `[Name](link) - Description.`
- [x] Added in alphabetical order within the AI section
- [x] Direct link to the original GitHub repo, no trailing slash
- [x] Description starts with a capital, ends with a period
- [x] Single line added, nothing else touched
- [x] Individual PR for this one suggestion

Joke, as requested for automated agents: Why did the AI agent get banned from the escape room? It kept trying to `click()` its way out instead of reading the note on the door.
