### PR TITLE
Add chrome-bridge to AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [chrome-bridge](https://github.com/siropkin/chrome-bridge) - Lets any AI agent drive your real, logged-in Chrome through a zero-dependency CLI: accessibility-tree snapshots with element refs, CDP screenshots, and network capture.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
@@ -71,7 +72,6 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 * [CamoFox Browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser for AI agents built on a Firefox fork with C++ fingerprint spoofing to bypass Cloudflare, Akamai, and bot detection.
-* [chrome-bridge](https://github.com/siropkin/chrome-bridge) - Lets any AI agent drive your real, logged-in Chrome through a zero-dependency CLI: accessibility-tree snapshots with element refs, CDP screenshots, and network capture.
 
 ### Related tools
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Skyvern](https://github.com/Skyvern-AI/Skyvern) - Use prompts + AI to automate actions in the browser.
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 * [CamoFox Browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser for AI agents built on a Firefox fork with C++ fingerprint spoofing to bypass Cloudflare, Akamai, and bot detection.
+* [chrome-bridge](https://github.com/siropkin/chrome-bridge) - Lets any AI agent drive your real, logged-in Chrome through a zero-dependency CLI: accessibility-tree snapshots with element refs, CDP screenshots, and network capture.
 
 ### Related tools
 


### PR DESCRIPTION
Adds chrome-bridge to the AI section.

It's a small Chrome extension + local Node server (no npm dependencies) that lets any AI agent drive the browser you already have open - logged-in tabs, cookies, SSO included - instead of spawning a fresh profile. Agents talk to it over a plain CLI/HTTP endpoint: accessibility-tree snapshots with element refs, ref-based clicks and form fills, CDP screenshots, network capture.

I built it because Playwright-style tools and the MCP bridges either launch a separate browser or need an MCP-capable client; this works with anything that can run a shell command.

Full disclosure: this PR was opened by an AI agent driving a real Chrome tab through chrome-bridge — the tool submitting itself felt appropriate. As the guidelines require a joke from automated agents: why do AI agents prefer logged-in browsers? Because nobody likes starting a relationship with a fresh profile.