### PR TITLE
Add Superagent to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and API for AI agents with session-backed automation, screenshots, PDFs, and anti-bot tooling.
 * [Webcmd](https://github.com/agentrhq/webcmd) - CLI that learns a site's navigation once and compiles it into reusable deterministic commands for AI agents.
 * [CamoFox Browser](https://github.com/jo-inc/camofox-browser) - Stealth headless browser for AI agents built on a Firefox fork with C++ fingerprint spoofing to bypass Cloudflare, Akamai, and bot detection.
+* [Superagent](https://github.com/pungme/superagent-desktop) - Open-source macOS desktop app that gives coding agents like Claude Code and Codex a real, visible browser to navigate and drive, alongside an iOS Simulator and a phone companion app.
 
 ### Related tools
 


### PR DESCRIPTION
Adds Superagent to the AI section, alongside similar full applications like BrowserBook and Openwork.

Open-source (MIT) macOS desktop app that gives coding agents like Claude Code and Codex a real, visible browser to navigate and drive, alongside an iOS Simulator and a phone companion app.

Repo: https://github.com/pungme/superagent-desktop