### PR TITLE
docs(ai): add Dao Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 * [Alumnium](https://alumnium.ai) - Open-source AI-powered test automation library on top of Playwright/Selenium.
 * [BrowserBook](https://browserbook.com) - AI-powered browser automation IDE with inline browser & coding agent built on top of Playwright.
 * [Browser-Use](https://github.com/browser-use/browser-use) - Python library and service to automate browsing using AI agents and Chrome DevTools Protocol.
+* [Dao Browser](https://github.com/msgbyte/dao-browser) - Chromium-based, Arc-style browser for macOS with a local MCP server that lets AI agents control live tabs through 31 native browser tools.
 * [Libretto](https://github.com/saffron-health/libretto) - Open-source Playwright-based toolkit and CLI for coding agents to inspect pages, capture network traffic, record actions, and generate automation scripts.
 * [onUI](https://github.com/onllm-dev/onUI) - Browser extension and MCP server for annotation-first UI pair programming with AI agents.
 * [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.


### PR DESCRIPTION
Adds Dao Browser to the AI section.

Dao is an open-source, Chromium-based, Arc-style browser for macOS. Its local MCP server lets external AI clients control live tabs through 31 native browser tools.