### PR TITLE
Add AntiBrow to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Collect structured data from Google Maps, YouTube, Instagram, Amazon, Google Sea
 
 ## Tools
  
+* [AntiBrow](https://antibrow.com) - Kernel-level antidetect browser exposing a standard Playwright BrowserContext over CDP; fingerprints applied in the C++ layer rather than injected scripts.
 * [Axiom](https://axiom.ai) - No code browser automation tool, like Zapier.
 * [Browserflow](https://browserflow.app) - Chrome extension to automate your local browser or in the cloud.
 * [Capybara](https://github.com/teamcapybara/capybara) - Driver-agnostic tool and DSL to write automation tests in Ruby.


### PR DESCRIPTION
Adds [AntiBrow](https://antibrow.com) to the list.

It is a kernel-level antidetect Chromium: fingerprints are applied in the C++ layer rather than through injected page scripts, and it hands back a standard Playwright `BrowserContext` over CDP, so it drops into an existing Playwright script without a new SDK. Windows, macOS and Linux; unlimited local profiles on the free tier with the profile data staying on the user's own disk.

Source and SDKs: https://github.com/antibrow/antibrow (MIT SDK, ~330 stars)

Entry follows the format already used in that section. Happy to reword or drop it if it is not a fit.
